### PR TITLE
[NETOBSERV-2885][QE] Status page via OLM Page

### DIFF
--- a/web/cypress/fixtures/vmi/hyperconverged-cr.yaml
+++ b/web/cypress/fixtures/vmi/hyperconverged-cr.yaml
@@ -1,0 +1,6 @@
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec: {}

--- a/web/cypress/fixtures/vmi/kubevirt-operator-group.yaml
+++ b/web/cypress/fixtures/vmi/kubevirt-operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kubevirt-hyperconverged-group
+  namespace: openshift-cnv
+spec:
+  targetNamespaces:
+    - openshift-cnv

--- a/web/cypress/fixtures/vmi/kubevirt-priority-class.yaml
+++ b/web/cypress/fixtures/vmi/kubevirt-priority-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: kubevirt-cluster-critical
+value: 1000000000
+globalDefault: false
+description: Priority class for KubeVirt critical cluster components

--- a/web/cypress/fixtures/vmi/kubevirt-subscription.yaml
+++ b/web/cypress/fixtures/vmi/kubevirt-subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kubevirt-hyperconverged
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/web/cypress/fixtures/vmi/test-vm.yaml
+++ b/web/cypress/fixtures/vmi/test-vm.yaml
@@ -1,0 +1,41 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: test-vm
+  namespace: test-vm
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: test-vm
+    spec:
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+        resources:
+          requests:
+            memory: 1Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - containerDisk:
+            image: quay.io/containerdisks/fedora:latest
+          name: containerdisk
+        - cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              password: fedora
+              chpasswd:
+                expire: false
+          name: cloudinitdisk

--- a/web/cypress/integration-tests/flowcollector_status.cy.ts
+++ b/web/cypress/integration-tests/flowcollector_status.cy.ts
@@ -1,7 +1,7 @@
 import { Operator } from "@views/netobserv"
 import { flowcollectorStatusPage, flowcollectorStatusSelectors } from "@views/flowcollector-status"
 
-describe('FlowCollector status error scenario', { tags: ['Network_Observability'] }, function () {
+describe('Network_Observability FlowCollector status error scenario', { tags: ['Network_Observability'] }, function () {
 
     before('setup', function () {
         cy.adminCLI(`oc adm policy add-cluster-role-to-user cluster-admin ${Cypress.env('LOGIN_USERNAME')}`)
@@ -12,7 +12,7 @@ describe('FlowCollector status error scenario', { tags: ['Network_Observability'
         Operator.createFlowcollector("WithLokiStack")
     })
 
-    it("(OCP-88744 kapjain) Verify error status when Loki enabled without LokiStack", function () {
+    it("(OCP-88744, kapjain) Verify error status when Loki enabled without LokiStack", function () {
         // Visit status page and wait for Ready condition to show False (error state)
         flowcollectorStatusPage.visit()
         cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 120000 }).should('exist')

--- a/web/cypress/integration-tests/static_plugin.cy.ts
+++ b/web/cypress/integration-tests/static_plugin.cy.ts
@@ -59,7 +59,8 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         // Updating ebpf Sampling to 1
         cy.get(pluginSelectors.editFlowcollector).click()
         cy.get('#root_spec_agent_accordion-toggle').click()
-        cy.get('#root_spec_agent_ebpf_sampling').clear().type('1')
+        cy.get('#root_spec_agent_ebpf_sampling').clear()
+        cy.get('#root_spec_agent_ebpf_sampling').type('1')
         cy.get(pluginSelectors.update).click()
 
         // Wait for flowcollector to get ready
@@ -78,14 +79,13 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         cy.checkNetflowTraffic()
         netflowPage.resetClearFilters()
     })
-
     it("(OCP-88744, kapjain) Verify OLM page 'cluster' click opens status page", function () {
         Operator.visitFlowcollector()
 
         cy.contains('td a', 'cluster', { timeout: 30000 }).should('be.visible')
             .invoke('attr', 'href').then(href => {
-                cy.visit(href as string)
-            })
+            cy.visit(href as string)
+        })
 
         cy.url({ timeout: 30000 }).should('include', '/flows.netobserv.io~v1beta2~FlowCollector/cluster')
         cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
@@ -113,43 +113,6 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         cy.get(flowcollectorStatusSelectors.statusIndicator).click()
         cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
     })
-    it("(OCP-88744, kapjain) Verify Edit FlowCollector button opens edit page", function () {
-        flowcollectorStatusPage.visit()
-
-        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('exist').click()
-        cy.url({ timeout: 30000 }).should('include', '/flows.netobserv.io~v1beta2~FlowCollector/edit')
-        cy.get(pluginSelectors.update, { timeout: 30000 }).should('exist')
-    })
-
-    it("(OCP-88744, kapjain) Verify Open Network Traffic button opens traffic page", function () {
-        flowcollectorStatusPage.visit()
-
-        cy.byLegacyTestID('open-network-traffic').should('exist')
-            .should('not.have.attr', 'aria-disabled', 'true')
-            .click()
-        cy.url({ timeout: 30000 }).should('include', '/netflow-traffic')
-    })
-    it("(OCP-88744, kapjain) Verify delete button exists and delete modal cancel works", function () {
-        flowcollectorStatusPage.visit()
-
-        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('exist')
-        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).should('exist')
-            .should('contain.text', 'Delete FlowCollector')
-
-        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).click()
-
-        cy.get(flowcollectorStatusSelectors.deleteModal, { timeout: 10000 }).should('exist')
-        cy.get(flowcollectorStatusSelectors.deleteModal).should('contain.text', 'Delete FlowCollector cluster')
-        cy.get(flowcollectorStatusSelectors.deleteModal).should('contain.text', 'This action cannot be undone')
-        cy.get(flowcollectorStatusSelectors.deleteModal)
-            .should('contain.text', 'It will disable flow collection globally')
-
-        cy.get(flowcollectorStatusSelectors.cancelDeleteBtn).should('exist').click()
-
-        cy.get(flowcollectorStatusSelectors.deleteModal).should('not.exist')
-        cy.get(flowcollectorStatusSelectors.readyRow).should('exist')
-    })
-
     it("(OCP-88744, kapjain) Verify delete FlowCollector reloads status page with only create option", function () {
         flowcollectorStatusPage.visit()
 
@@ -160,10 +123,6 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         cy.get(flowcollectorStatusSelectors.createFlowCollectorBtn, { timeout: 60000 }).should('exist')
         cy.contains('No FlowCollector resource was found', { timeout: 30000 }).should('exist')
         cy.contains('Create one to enable network flow collection').should('exist')
-
-        cy.get(flowcollectorStatusSelectors.statusButton).should('not.exist')
-        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('not.exist')
-        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).should('not.exist')
 
         cy.get(flowcollectorStatusSelectors.createFlowCollectorBtn)
             .should('contain.text', 'Create FlowCollector')

--- a/web/cypress/integration-tests/static_plugin.cy.ts
+++ b/web/cypress/integration-tests/static_plugin.cy.ts
@@ -79,27 +79,96 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         netflowPage.resetClearFilters()
     })
 
-        it("(OCP-88744 kapjain) Verify status indicator on Network Health page", function () {
-            cy.visit('/network-health')
+    it("(OCP-88744, kapjain) Verify OLM page 'cluster' click opens status page", function () {
+        Operator.visitFlowcollector()
 
-            cy.get(flowcollectorStatusSelectors.statusIndicator).should('exist')
-                .find('span').first().trigger('mouseenter', { force: true })
-            cy.get(flowcollectorStatusSelectors.statusTooltip, { timeout: 10000 })
-                .should('contain.text', 'FlowCollector is ready')
-            cy.get(flowcollectorStatusSelectors.statusIndicator).click()
-            cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
-        })
+        cy.contains('td a', 'cluster', { timeout: 30000 }).should('be.visible')
+            .invoke('attr', 'href').then(href => {
+                cy.visit(href as string)
+            })
 
-        it("(OCP-88744 kapjain) Verify status indicator on Network Traffic page", function () {
-            cy.visit('/netflow-traffic')
+        cy.url({ timeout: 30000 }).should('include', '/flows.netobserv.io~v1beta2~FlowCollector/cluster')
+        cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
+        cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 120000 }).should('exist')
+    })
 
-            cy.get(flowcollectorStatusSelectors.statusIndicator).should('exist')
-                .find('span').first().trigger('mouseenter', { force: true })
-            cy.get(flowcollectorStatusSelectors.statusTooltip, { timeout: 10000 })
-                .should('contain.text', 'FlowCollector is ready')
-            cy.get(flowcollectorStatusSelectors.statusIndicator).click()
-            cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
-        })
+    it("(OCP-88744 kapjain) Verify status indicator on Network Health page", function () {
+        cy.visit('/network-health')
+
+        cy.get(flowcollectorStatusSelectors.statusIndicator).should('exist')
+            .find('span').first().trigger('mouseenter', { force: true })
+        cy.get(flowcollectorStatusSelectors.statusTooltip, { timeout: 10000 })
+            .should('contain.text', 'FlowCollector is ready')
+        cy.get(flowcollectorStatusSelectors.statusIndicator).click()
+        cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
+    })
+
+    it("(OCP-88744 kapjain) Verify status indicator on Network Traffic page", function () {
+        cy.visit('/netflow-traffic')
+
+        cy.get(flowcollectorStatusSelectors.statusIndicator).should('exist')
+            .find('span').first().trigger('mouseenter', { force: true })
+        cy.get(flowcollectorStatusSelectors.statusTooltip, { timeout: 10000 })
+            .should('contain.text', 'FlowCollector is ready')
+        cy.get(flowcollectorStatusSelectors.statusIndicator).click()
+        cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
+    })
+    it("(OCP-88744, kapjain) Verify Edit FlowCollector button opens edit page", function () {
+        flowcollectorStatusPage.visit()
+
+        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('exist').click()
+        cy.url({ timeout: 30000 }).should('include', '/flows.netobserv.io~v1beta2~FlowCollector/edit')
+        cy.get(pluginSelectors.update, { timeout: 30000 }).should('exist')
+    })
+
+    it("(OCP-88744, kapjain) Verify Open Network Traffic button opens traffic page", function () {
+        flowcollectorStatusPage.visit()
+
+        cy.byLegacyTestID('open-network-traffic').should('exist')
+            .should('not.have.attr', 'aria-disabled', 'true')
+            .click()
+        cy.url({ timeout: 30000 }).should('include', '/netflow-traffic')
+    })
+    it("(OCP-88744, kapjain) Verify delete button exists and delete modal cancel works", function () {
+        flowcollectorStatusPage.visit()
+
+        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('exist')
+        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).should('exist')
+            .should('contain.text', 'Delete FlowCollector')
+
+        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).click()
+
+        cy.get(flowcollectorStatusSelectors.deleteModal, { timeout: 10000 }).should('exist')
+        cy.get(flowcollectorStatusSelectors.deleteModal).should('contain.text', 'Delete FlowCollector cluster')
+        cy.get(flowcollectorStatusSelectors.deleteModal).should('contain.text', 'This action cannot be undone')
+        cy.get(flowcollectorStatusSelectors.deleteModal)
+            .should('contain.text', 'It will disable flow collection globally')
+
+        cy.get(flowcollectorStatusSelectors.cancelDeleteBtn).should('exist').click()
+
+        cy.get(flowcollectorStatusSelectors.deleteModal).should('not.exist')
+        cy.get(flowcollectorStatusSelectors.readyRow).should('exist')
+    })
+
+    it("(OCP-88744, kapjain) Verify delete FlowCollector reloads status page with only create option", function () {
+        flowcollectorStatusPage.visit()
+
+        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).click()
+        cy.get(flowcollectorStatusSelectors.deleteModal, { timeout: 10000 }).should('exist')
+        cy.get(flowcollectorStatusSelectors.confirmDeleteBtn).should('exist').click()
+
+        cy.get(flowcollectorStatusSelectors.createFlowCollectorBtn, { timeout: 60000 }).should('exist')
+        cy.contains('No FlowCollector resource was found', { timeout: 30000 }).should('exist')
+        cy.contains('Create one to enable network flow collection').should('exist')
+
+        cy.get(flowcollectorStatusSelectors.statusButton).should('not.exist')
+        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('not.exist')
+        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).should('not.exist')
+
+        cy.get(flowcollectorStatusSelectors.createFlowCollectorBtn)
+            .should('contain.text', 'Create FlowCollector')
+    })
+
     after("after all tests", function () {
         Operator.deleteFlowCollector()
         cy.adminCLI(`oc adm policy remove-cluster-role-from-user cluster-admin ${Cypress.env('LOGIN_USERNAME')}`)

--- a/web/cypress/integration-tests/vmi_network_traffic.cy.ts
+++ b/web/cypress/integration-tests/vmi_network_traffic.cy.ts
@@ -1,0 +1,225 @@
+import "@views/netobserv"
+import { Operator } from "@views/netobserv"
+import { netflowPage } from "@views/netflow-page"
+
+const VMI_NAMESPACE = "test-vm"
+const VMI_NAME = "test-vm"
+
+describe('(NETOBSERV-2693) Network Traffic Tab on VMI Page', { tags: ['Network_Observability'] }, function () {
+
+    before('setup', function () {
+        // Add cluster admin role and login first (like other tests)
+        cy.adminCLI(`oc adm policy add-cluster-role-to-user cluster-admin ${Cypress.env('LOGIN_USERNAME')}`)
+        cy.uiLogin(Cypress.env('LOGIN_IDP'), Cypress.env('LOGIN_USERNAME'), Cypress.env('LOGIN_PASSWORD'))
+
+        // Install NetObserv operator
+        if (`${Cypress.env('SKIP_NOO_INSTALL')}` !== 'true') {
+            Operator.install()
+        }
+
+        cy.checkStorageClass(this)
+        Operator.createFlowcollector()
+        // Setup KubeVirt operator
+        cy.adminCLI(`oc create namespace openshift-cnv`, { failOnNonZeroExit: false } as any)
+        cy.adminCLI(`oc apply -f ./cypress/fixtures/vmi/kubevirt-operator-group.yaml`)
+        cy.adminCLI(`oc apply -f ./cypress/fixtures/vmi/kubevirt-subscription.yaml`)
+        cy.adminCLI(`oc apply -f ./cypress/fixtures/vmi/kubevirt-priority-class.yaml`)
+
+        // Wait for subscription to create InstallPlan and CSV
+        cy.checkCommandResult(
+            "oc get subscription kubevirt-hyperconverged -n openshift-cnv -o jsonpath='{.status.installedCSV}'",
+            'kubevirt',
+            { retries: 30, interval: 10000 }
+        )
+
+        // Wait for CNV operator CSV to be Succeeded
+        cy.checkCommandResult(
+            "oc get csv -n openshift-cnv -o jsonpath='{.items[*].status.phase}'",
+            'Succeeded',
+            { retries: 60, interval: 20000 }
+        )
+
+        // Wait for webhook pod to be ready before creating HyperConverged CR
+        cy.checkCommandResult(
+            "oc get pods -n openshift-cnv -l name=hyperconverged-cluster-webhook -o jsonpath='{.items[*].status.conditions[?(@.type==\"Ready\")].status}' 2>/dev/null",
+            'True',
+            { retries: 30, interval: 10000 }
+        )
+
+        // Create HyperConverged CR
+        cy.adminCLI(`oc apply -f ./cypress/fixtures/vmi/hyperconverged-cr.yaml`)
+        cy.wait(5000)
+
+        // Wait for HyperConverged to be available
+        cy.checkCommandResult(
+            "oc get hyperconverged kubevirt-hyperconverged -n openshift-cnv -o jsonpath='{.status.conditions[?(@.type==\"Available\")].status}'",
+            'True',
+            { retries: 60, interval: 20000 }
+        )
+
+        // Wait for KubeVirt CR to be created by HyperConverged operator
+        cy.checkCommandResult(
+            "oc get kubevirt kubevirt-kubevirt-hyperconverged -n openshift-cnv -o jsonpath='{.metadata.name}'",
+            'kubevirt-kubevirt-hyperconverged',
+            { retries: 60, interval: 10000 }
+        )
+
+        // Enable software emulation via JSON patch annotation
+        cy.adminCLI(`oc annotate hyperconverged kubevirt-hyperconverged -n openshift-cnv 'kubevirt.kubevirt.io/jsonpatch=[{"op":"add","path":"/spec/configuration/developerConfiguration/useEmulation","value":true}]' --overwrite`)
+
+        // Wait for emulation to be applied on KubeVirt CR
+        cy.checkCommandResult(
+            "oc get kubevirt kubevirt-kubevirt-hyperconverged -n openshift-cnv -o jsonpath='{.spec.configuration.developerConfiguration.useEmulation}'",
+            'true',
+            { retries: 30, interval: 10000 }
+        )
+
+        // Restart virt-handler pods to pick up emulation config
+        cy.adminCLI('oc delete pods -n openshift-cnv -l kubevirt.io=virt-handler')
+        cy.checkCommandResult(
+            "oc get pods -n openshift-cnv -l kubevirt.io=virt-handler -o jsonpath='{.items[0].status.phase}'",
+            'Running',
+            { retries: 15, interval: 10000 }
+        )
+
+        // Create test VM namespace and VM
+        cy.adminCLI(`oc create namespace ${VMI_NAMESPACE}`, { failOnNonZeroExit: false } as any)
+        cy.adminCLI(`oc apply -f ./cypress/fixtures/vmi/test-vm.yaml`)
+
+        // Wait for VM to be running
+        cy.checkCommandResult(
+            `oc get vm ${VMI_NAME} -n ${VMI_NAMESPACE} -o jsonpath='{.status.printableStatus}'`,
+            'Running',
+            { retries: 30, interval: 20000 }
+        )
+
+        // Generate network traffic from the VM by making requests from virt-launcher pod
+        cy.adminCLI(`oc get pods -n ${VMI_NAMESPACE} -l kubevirt.io/domain=${VMI_NAME} -o jsonpath='{.items[0].metadata.name}'`)
+            .then((result: any) => {
+                const podName = result.stdout.trim()
+                cy.wrap(podName).should('not.be.empty', 'virt-launcher pod should exist')
+                // Generate multiple curl requests to ensure traffic is captured
+                cy.adminCLI(`oc exec -n ${VMI_NAMESPACE} ${podName} -- timeout 10 curl -v http://8.8.8.8 2>&1 | head -20`, { failOnNonZeroExit: false } as any)
+                cy.wait(2000)
+                cy.adminCLI(`oc exec -n ${VMI_NAMESPACE} ${podName} -- timeout 10 curl -v http://8.8.8.8 2>&1 | head -20`, { failOnNonZeroExit: false } as any)
+            })
+
+        // Wait for flows to be ingested into Loki by polling flow-collector logs
+        cy.adminCLI(`oc logs -n netobserv -l app=netobserv-plugin,component=flow-collector --tail=100 2>/dev/null | grep -i "packet\\|flow" || echo "waiting"`, { retries: 30, interval: 5000 })
+    })
+
+    it('(NETOBSERV-2693, kapjain) Navigate from Search to VMI and verify Network Traffic on virt-launcher Pod', { tags: ["@smoke"] }, function () {
+        // Navigate to search page with VirtualMachineInstance resource pre-selected
+        cy.visit(`/search/ns/${VMI_NAMESPACE}?kind=kubevirt.io~v1~VirtualMachineInstance`)
+
+        // Verify VMI appears in search results and click on it
+        cy.get('tbody tr', { timeout: 30000 }).should('have.length.greaterThan', 0)
+        cy.get('tbody tr', { timeout: 30000 }).contains(VMI_NAME).click()
+
+        // Verify we are on the VMI detail page
+        cy.url().should('contain', 'VirtualMachineInstance')
+        cy.url().should('contain', VMI_NAME)
+
+        // Navigate to the virt-launcher Pod from VMI detail page
+        cy.contains('a', 'virt-launcher', { timeout: 30000 }).should('exist').click()
+
+        // Verify we are on the Pod detail page
+        cy.url().should('contain', 'pods')
+        cy.wait(2000)
+
+        // Click on Network Traffic tab
+        cy.byLegacyTestID('horizontal-link-Network Traffic').should('be.visible', { timeout: 60000 }).click()
+
+        // Increase time range to capture flows
+        cy.byTestID('time-range-dropdown-dropdown').should('be.visible', { timeout: 30000 }).click()
+        cy.get('[data-test="1h"]').should('be.visible', { timeout: 10000 }).click()
+
+        // Wait for page to stabilize and allow flows to load
+        cy.wait(5000)
+
+        // Verify traffic flows are present in the table tab
+        cy.get('#tabs-container').contains('Traffic flows').click()
+
+        // Click refresh button to reload flows
+        cy.get('[data-test="refresh-button"]').should('be.visible').click()
+        cy.wait(2000)
+
+        cy.get('[data-test="table-composable"]', { timeout: 120000 }).should('exist')
+        cy.get('[data-test="table-composable"] tbody tr', { timeout: 120000 }).should('have.length.greaterThan', 0)
+
+        cy.wait(3000)
+
+        // Verify overview tab loads with panels
+        cy.get('#tabs-container').contains('Overview').click({ force: true })
+        netflowPage.waitForLokiQuery()
+        cy.get('#overview-flex', { timeout: 120000 }).should('exist')
+
+        // Verify topology tab loads with graph content
+        cy.get('#tabs-container').contains('Topology').click()
+        cy.get('#drawer', { timeout: 120000 }).should('exist')
+    })
+
+    it('(NETOBSERV-2761, kapjain) Navigate from Virtualization VM page and verify Network Traffic on virt-launcher Pod', { tags: ["@smoke"] }, function () {
+        // Navigate to the VirtualMachine detail page via Virtualization
+        cy.visit(`/k8s/ns/${VMI_NAMESPACE}/kubevirt.io~v1~VirtualMachine/${VMI_NAME}`)
+
+        // Verify we are on the VM detail page
+        cy.url().should('contain', 'VirtualMachine')
+        cy.url().should('contain', VMI_NAME)
+        cy.contains(VMI_NAME, { timeout: 30000 }).should('exist')
+
+        // Give page time to fully load
+        cy.wait(3000)
+
+        // Navigate to the virt-launcher Pod from VM detail page
+        cy.contains('a', 'virt-launcher', { timeout: 30000 }).should('be.visible').click()
+
+        // Verify we are on the Pod detail page
+        cy.url().should('contain', 'pods')
+        cy.wait(2000)
+
+        // Click on Network Traffic tab
+        cy.byLegacyTestID('horizontal-link-Network Traffic').should('be.visible', { timeout: 60000 }).click()
+
+        // Increase time range to capture flows
+        cy.byTestID('time-range-dropdown-dropdown').should('be.visible', { timeout: 30000 }).click()
+        cy.get('[data-test="1h"]').should('be.visible', { timeout: 10000 }).click()
+
+        // Verify traffic flows are present in the table tab
+        cy.get('#tabs-container').contains('Traffic flows').click()
+
+        // Click refresh button to reload flows
+        cy.get('[data-test="refresh-button"]').should('be.visible').click()
+        cy.wait(2000)
+
+        cy.get('[data-test="table-composable"]', { timeout: 120000 }).should('exist')
+        cy.get('[data-test="table-composable"] tbody tr', { timeout: 120000 }).should('have.length.greaterThan', 0)
+
+        cy.wait(3000)
+
+        // Verify overview tab loads with panels
+        cy.get('#tabs-container').contains('Overview').click({ force: true })
+        netflowPage.waitForLokiQuery()
+        cy.get('#overview-flex', { timeout: 120000 }).should('exist')
+
+        // Verify topology tab loads with graph content
+        cy.get('#tabs-container').contains('Topology').click()
+        cy.get('#drawer', { timeout: 120000 }).should('exist')
+    })
+
+    after("cleanup", function () {
+        // Delete test VM and namespace
+        cy.adminCLI(`oc delete vm ${VMI_NAME} -n ${VMI_NAMESPACE}`, { failOnNonZeroExit: false } as any)
+        cy.adminCLI(`oc delete namespace ${VMI_NAMESPACE} --wait=false`, { failOnNonZeroExit: false } as any)
+
+        // Delete HyperConverged CR (leave CNV operator installed to avoid slow reinstall)
+        cy.adminCLI('oc delete hyperconverged kubevirt-hyperconverged -n openshift-cnv --wait=false', { failOnNonZeroExit: false } as any)
+
+        // Delete FlowCollector if not skipping NetObserv install
+        if (`${Cypress.env('SKIP_NOO_INSTALL')}` !== 'true') {
+            Operator.deleteFlowCollector()
+        }
+
+        cy.adminCLI(`oc adm policy remove-cluster-role-from-user cluster-admin ${Cypress.env('LOGIN_USERNAME')}`)
+    })
+})

--- a/web/cypress/support/console-utilities.ts
+++ b/web/cypress/support/console-utilities.ts
@@ -26,6 +26,11 @@ Cypress.on('uncaught:exception', (err) => {
     return false;
   }
 
+  // Ignore transient errors in console application
+  if (typeof err.message === 'string' && (err.message.includes('is not a function') || err.message.includes('listener is not a function'))) {
+    return false;
+  }
+
   return true; // test fails
 });
 

--- a/web/cypress/views/flowcollector-status.ts
+++ b/web/cypress/views/flowcollector-status.ts
@@ -21,16 +21,6 @@ export namespace flowcollectorStatusSelectors {
 export const flowcollectorStatusPage = {
     visit: () => {
         cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')
-        cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 120000 })
-            .should('have.attr', 'data-test-status', 'True')
-            .should('have.attr', 'data-test-reason', 'Ready')
-    },
-    visitWithoutWaitingForReady: () => {
-        cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')
-        cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
-    },
-    visitViaClusterPath: () => {
-        cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/cluster')
         cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
     }
 }

--- a/web/cypress/views/flowcollector-status.ts
+++ b/web/cypress/views/flowcollector-status.ts
@@ -21,7 +21,9 @@ export namespace flowcollectorStatusSelectors {
 export const flowcollectorStatusPage = {
     visit: () => {
         cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')
-        cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 30000 }).should('exist')
+        cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 120000 })
+            .should('have.attr', 'data-test-status', 'True')
+            .should('have.attr', 'data-test-reason', 'Ready')
     },
     visitWithoutWaitingForReady: () => {
         cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')

--- a/web/cypress/views/flowcollector-status.ts
+++ b/web/cypress/views/flowcollector-status.ts
@@ -10,11 +10,25 @@ export namespace flowcollectorStatusSelectors {
     export const flpMonolithRow = '[id=WaitingFLPMonolith-row]'
     export const lokiStackRow = '[id=WaitingLokiStack-row]'
     export const flpParentRow = '[id=WaitingFLPParent-row]'
+    export const deleteFlowCollectorBtn = '[data-test-id="delete-flow-collector"]'
+    export const editFlowCollectorBtn = '[data-test-id="edit-flow-collector"]'
+    export const createFlowCollectorBtn = '[data-test-id="create-flow-collector"]'
+    export const deleteModal = '#delete-modal'
+    export const confirmDeleteBtn = '[data-test-id="confirm-delete-popup-button"]'
+    export const cancelDeleteBtn = '[data-test-id="cancel-delete-popup-button"]'
 }
 
 export const flowcollectorStatusPage = {
     visit: () => {
         cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')
         cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 30000 }).should('exist')
+    },
+    visitWithoutWaitingForReady: () => {
+        cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')
+        cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
+    },
+    visitViaClusterPath: () => {
+        cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/cluster')
+        cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
     }
 }


### PR DESCRIPTION
## Description

Test cases for change [NETOBSERV-2693](https://redhat.atlassian.net/browse/NETOBSERV-2693) Open Flowcollector status page from OLM page
    
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for FlowCollector navigation and lifecycle actions.
  * Added validation for status indicators on Network Health and Network Traffic pages.
  * Covered editing, opening Network Traffic, canceling deletion, and deleting a FlowCollector.
  * Added automated coverage for creating and deleting FlowCollectors, including confirmation dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->