### PR TITLE
NETOBSERV-2671: support DNS metrics per qname (#1673) [pf5 backport]

### DIFF
--- a/pkg/handler/promproxy.go
+++ b/pkg/handler/promproxy.go
@@ -45,6 +45,7 @@ func simpleProxy(toURLStr string, timeout time.Duration, skipTLS bool, caPath st
 			URL:           &backendURL,
 			Body:          r.Body,
 			ContentLength: r.ContentLength,
+			Header:        http.Header{},
 		}
 		resp, err := roundTripper.RoundTrip(&rq)
 		if err != nil {

--- a/pkg/loki/flow_query.go
+++ b/pkg/loki/flow_query.go
@@ -207,23 +207,6 @@ func (q *FlowQueryBuilder) appendFilter(sb *strings.Builder, field string) {
 	sb.WriteString("\"`")
 }
 
-func (q *FlowQueryBuilder) appendDNSFilter(sb *strings.Builder) {
-	// ensure at least one Dns field is specified except DnsErrno
-	// |~`"DnsId`|~`"DnsName`|~`"DnsLatencyMs`|~`"DnsFlagsResponseCode"`
-	sb.WriteString("|~`")
-	sb.WriteString(`"DnsId`)
-	sb.WriteString("`")
-	sb.WriteString("|~`")
-	sb.WriteString(`"DnsName`)
-	sb.WriteString("`")
-	sb.WriteString("|~`")
-	sb.WriteString(`"DnsLatencyMs`)
-	sb.WriteString("`")
-	sb.WriteString("|~`")
-	sb.WriteString(`"DnsFlagsResponseCode"`)
-	sb.WriteString("`")
-}
-
 func (q *FlowQueryBuilder) appendTLSFilter(sb *strings.Builder) {
 	sb.WriteString(`|="TLSTypes"`)
 }
@@ -236,14 +219,6 @@ func (q *FlowQueryBuilder) appendDNSLatencyFilter(sb *strings.Builder) {
 	sb.WriteString("`")
 	sb.WriteString("!~`")
 	sb.WriteString(`"DnsLatencyMs":0[,}]`)
-	sb.WriteString("`")
-}
-
-func (q *FlowQueryBuilder) appendRTTFilter(sb *strings.Builder) {
-	// ensure at TimeFlowRttNs field is specified
-	// |~`"TimeFlowRttNs"`
-	sb.WriteString("|~`")
-	sb.WriteString(`"TimeFlowRttNs"`)
 	sb.WriteString("`")
 }
 

--- a/pkg/loki/topology_query.go
+++ b/pkg/loki/topology_query.go
@@ -134,11 +134,11 @@ func (q *TopologyQueryBuilder) Build() string {
 	case constants.MetricTypeDNSLatency:
 		q.appendDNSLatencyFilter(sb)
 	case constants.MetricTypeDNSFlows:
-		q.appendDNSFilter(sb)
+		q.appendFilter(sb, "DnsId")
 	case constants.MetricTypeTLSFlows:
 		q.appendTLSFilter(sb)
 	case constants.MetricTypeFlowRTT:
-		q.appendRTTFilter(sb)
+		q.appendFilter(sb, "TimeFlowRttNs")
 	}
 
 	q.appendJSON(sb, true)

--- a/pkg/prometheus/inventory.go
+++ b/pkg/prometheus/inventory.go
@@ -26,15 +26,10 @@ func NewInventory(cfg *config.Prometheus) *Inventory {
 		if cfg.Metrics[i].Direction == "" {
 			cfg.Metrics[i].Direction = config.AnyDirection
 		}
-		// Add DNS counter(s)
-		if strings.Contains(cfg.Metrics[i].Name, "_dns_latency_seconds") {
-			cpy := cfg.Metrics[i]
-			cpy.Name += "_count"
-			cpy.ValueField = constants.MetricTypeDNSFlows
-			toAppend = append(toAppend, cpy)
-		}
-		// Simulate Flows and TLSFlows value fields
-		if strings.Contains(cfg.Metrics[i].Name, "_tls_flows") {
+		// Simulate Flows, DNSFlows and TLSFlows value fields
+		if strings.Contains(cfg.Metrics[i].Name, "_dns_flows") {
+			cfg.Metrics[i].ValueField = constants.MetricTypeDNSFlows
+		} else if strings.Contains(cfg.Metrics[i].Name, "_tls_flows") {
 			cfg.Metrics[i].ValueField = constants.MetricTypeTLSFlows
 		} else if strings.Contains(cfg.Metrics[i].Name, "_flows") {
 			cfg.Metrics[i].ValueField = constants.MetricTypeFlows

--- a/pkg/prometheus/inventory_test.go
+++ b/pkg/prometheus/inventory_test.go
@@ -11,6 +11,13 @@ import (
 var configuredMetrics = []config.MetricInfo{
 	{
 		Enabled:   true,
+		Name:      "netobserv_metric_dns_flows_total",
+		Type:      "Counter",
+		Direction: config.AnyDirection,
+		Labels:    []string{"SrcK8S_Namespace", "DstK8S_Namespace"},
+	},
+	{
+		Enabled:   true,
 		Name:      "netobserv_metric_tls_flows_total",
 		Type:      "Counter",
 		Direction: config.AnyDirection,
@@ -108,6 +115,11 @@ func TestInventory_Search(t *testing.T) {
 	// Search TLS flows metrics
 	search = inv.Search([]string{"SrcK8S_Namespace", "DstK8S_Namespace"}, constants.MetricTypeTLSFlows)
 	assert.Equal(t, []string{"netobserv_metric_tls_flows_total"}, search.Found)
+	assert.Empty(t, search.Candidates)
+
+	// Search DNS flows metrics
+	search = inv.Search([]string{"SrcK8S_Namespace", "DstK8S_Namespace"}, constants.MetricTypeDNSFlows)
+	assert.Equal(t, []string{"netobserv_metric_dns_flows_total"}, search.Found)
 	assert.Empty(t, search.Candidates)
 }
 

--- a/pkg/prometheus/query.go
+++ b/pkg/prometheus/query.go
@@ -106,14 +106,14 @@ func (q *QueryBuilder) Build() Query {
 		if isHisto {
 			if quantile == "" {
 				// histogram average: sum / count
-				appendRate(&sb, metric+"_sum", q.filters, q.in.RateInterval)
+				appendRateOrIncrease(&sb, false, metric+"_sum", q.filters, q.in.RateInterval)
 				sb.WriteRune('/')
-				appendRate(&sb, metric+"_count", q.filters, q.in.RateInterval)
+				appendRateOrIncrease(&sb, false, metric+"_count", q.filters, q.in.RateInterval)
 			} else {
-				appendRate(&sb, metric+"_bucket", q.filters, q.in.RateInterval)
+				appendRateOrIncrease(&sb, false, metric+"_bucket", q.filters, q.in.RateInterval)
 			}
 		} else {
-			appendRate(&sb, metric, q.filters, q.in.RateInterval)
+			appendRateOrIncrease(&sb, q.in.MetricFunction == constants.MetricFunctionCount, metric, q.filters, q.in.RateInterval)
 		}
 		sb.WriteRune(')') // closes sum(...
 		if isHisto && quantile != "" {
@@ -135,8 +135,12 @@ func (q *QueryBuilder) Build() Query {
 	}
 }
 
-func appendRate(sb *strings.Builder, metric string, filters filters.SingleQuery, interval string) {
-	sb.WriteString("rate(")
+func appendRateOrIncrease(sb *strings.Builder, isIncrease bool, metric string, filters filters.SingleQuery, interval string) {
+	if isIncrease {
+		sb.WriteString("increase(")
+	} else {
+		sb.WriteString("rate(")
+	}
 	appendFilteredMetric(sb, metric, filters)
 	sb.WriteRune('[')
 	sb.WriteString(interval)

--- a/pkg/prometheus/query_test.go
+++ b/pkg/prometheus/query_test.go
@@ -172,18 +172,18 @@ func TestBuildQuery_PromQLByDNSResponseCode(t *testing.T) {
 	in := queryparams.TopologyInput{
 		Top:            "5",
 		RateInterval:   "1m",
-		DataField:      "DnsFlows",
+		DataField:      constants.MetricTypeDNSFlows,
 		MetricFunction: constants.MetricFunctionCount,
 		RecordType:     constants.RecordTypeLog,
 		DataSource:     constants.DataSourceAuto,
 		Aggregate:      "DnsFlagsResponseCode",
 	}
 	f := filters.SingleQuery{}
-	q := NewQuery(kl, &in, &qr, f, []string{"netobserv_namespace_dns_latency_seconds_count"})
+	q := NewQuery(kl, &in, &qr, f, []string{"netobserv_namespace_dns_flows_total"})
 	result := q.Build()
 	assert.Equal(
 		t,
-		`topk(5,sum by(DnsFlagsResponseCode)(rate(netobserv_namespace_dns_latency_seconds_count{DnsFlagsResponseCode!=""}[1m])))`,
+		`topk(5,sum by(DnsFlagsResponseCode)(increase(netobserv_namespace_dns_flows_total{DnsFlagsResponseCode!=""}[1m])))`,
 		result.PromQL,
 	)
 }

--- a/web/cypress/fixtures/flowcollector/fc_DNSTracking.yaml
+++ b/web/cypress/fixtures/flowcollector/fc_DNSTracking.yaml
@@ -21,3 +21,6 @@ spec:
         - namespace_dns_latency_seconds
         - node_dns_latency_seconds
         - workload_dns_latency_seconds
+        - namespace_dns_flows_total
+        - node_dns_flows_total
+        - workload_dns_flows_total

--- a/web/cypress/fixtures/flowcollector/fc_networkalert.yaml
+++ b/web/cypress/fixtures/flowcollector/fc_networkalert.yaml
@@ -28,6 +28,7 @@ spec:
       includeList:
       - workload_dns_latency_seconds
       - node_dns_latency_seconds
+      - namespace_dns_latency_seconds
       - node_egress_bytes_total
       - namespace_egress_bytes_total
       - workload_egress_bytes_total

--- a/web/cypress/views/netflow-page.ts
+++ b/web/cypress/views/netflow-page.ts
@@ -328,7 +328,7 @@ export namespace overviewSelectors {
      export const manageTLSTrackingPanelsList = ['TLS usage (donut or lines)', 'TLS usage per version (donut or lines)', 'TLS usage per group (donut or lines)', 'TLS usage per cipher suite (donut or lines)']
     export const defaultPanels = ['Top 5 average bytes rates', 'Top 5 bytes rates stacked with total']
     export const defaultPacketDropPanels = ['Top 5 packet dropped state stacked with total', 'Top 5 packet dropped cause stacked with total', 'Top 5 average dropped packets rates', 'Top 5 dropped packets rates stacked with total']
-    export const defaultDNSTrackingPanels = ['Top 5 DNS response code', 'Top 5 average DNS latencies with overall', 'Top 5 90th percentile DNS latencies']
+    export const defaultDNSTrackingPanels = ['Top 5 DNS name', 'Top 5 DNS response code', 'Top 5 average DNS latencies with overall', 'Top 5 90th percentile DNS latencies']
     export const defaultFlowRTTPanels = ['Top 5 average TCP smoothed Round Trip Time with overall', 'Bottom 5 minimum TCP smoothed Round Trip Time', 'Top 5 90th percentile TCP smoothed Round Trip Time']
     export const defaultTLSTrackingPanels = ['TLS usage (network flows per second)', 'TLS per version (network flows per second)']
     export const allPanels = defaultPanels.concat(['Top 5 average packets rates', 'Top 5 packets rates'])

--- a/web/src/components/__tests-data__/panels.ts
+++ b/web/src/components/__tests-data__/panels.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
-import { getDefaultOverviewPanels, OverviewPanel } from '../../utils/overview-panels';
+import { getAvailablePanels, OverviewPanel } from '../../utils/overview-panels';
 
 export const CustomPanelsSample = ['Flows', 'DnsFlows'];
 export const SamplePanel = { id: 'top_avg_byte_rates', isSelected: true } as OverviewPanel;
-export const DefaultPanels = getDefaultOverviewPanels().filter(p => p.isSelected);
+export const DefaultPanels = getAvailablePanels().filter(p => p.isSelected);
 export const ShuffledDefaultPanels: OverviewPanel[] = _.shuffle(DefaultPanels);

--- a/web/src/components/__tests__/netflow-traffic.spec.tsx
+++ b/web/src/components/__tests__/netflow-traffic.spec.tsx
@@ -92,10 +92,8 @@ describe('<NetflowTraffic />', () => {
       { ...defaultQuery, function: 'avg', aggregateBy: 'app', type: 'DnsLatencyMs' },
       { ...defaultQuery, function: 'p90', aggregateBy: 'app', type: 'DnsLatencyMs' },
       { ...defaultQuery, function: 'avg', type: 'TimeFlowRttNs' },
-      { ...defaultQuery, function: 'min', type: 'TimeFlowRttNs' },
       { ...defaultQuery, function: 'p90', type: 'TimeFlowRttNs' },
       { ...defaultQuery, function: 'avg', aggregateBy: 'app', type: 'TimeFlowRttNs' },
-      { ...defaultQuery, function: 'min', aggregateBy: 'app', type: 'TimeFlowRttNs' },
       { ...defaultQuery, function: 'p90', aggregateBy: 'app', type: 'TimeFlowRttNs' }
     ];
     const expectedGenericMetricsQueries: FlowQuery[] = [

--- a/web/src/components/modals/overview-panels-modal.tsx
+++ b/web/src/components/modals/overview-panels-modal.tsx
@@ -23,7 +23,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Feature } from '../../model/config';
 import { RecordType } from '../../model/flow-query';
-import { getDefaultOverviewPanels, getOverviewPanelInfo, OverviewPanel } from '../../utils/overview-panels';
+import { getAvailablePanels, getOverviewPanelInfo, OverviewPanel } from '../../utils/overview-panels';
 import Modal from './modal';
 import './overview-panels-modal.css';
 
@@ -164,7 +164,7 @@ export const OverviewPanelsModal: React.FC<OverviewPanelsModalProps> = ({
   );
 
   const onReset = React.useCallback(() => {
-    setUpdatedPanels(getDefaultOverviewPanels(customIds).filter(p => panels.some(existing => existing.id === p.id)));
+    setUpdatedPanels(getAvailablePanels(customIds).filter(p => panels.some(existing => existing.id === p.id)));
   }, [customIds, panels]);
 
   const isSaveDisabled = React.useCallback(() => {

--- a/web/src/components/tabs/netflow-overview/netflow-overview.tsx
+++ b/web/src/components/tabs/netflow-overview/netflow-overview.tsx
@@ -36,7 +36,7 @@ import { localStorageOverviewKebabKey, useLocalStorage } from '../../../utils/lo
 import { observeDOMRect, toNamedMetric } from '../../../utils/metrics-helper';
 import {
   customPanelMatcher,
-  dnsIdMatcher,
+  dnsMatcher,
   droppedIdMatcher,
   getFunctionFromId,
   getOverviewPanelInfo,
@@ -253,59 +253,52 @@ export const NetflowOverview = React.forwardRef<NetflowOverviewHandle, NetflowOv
         });
       }
 
-      const dnsPanels = props.panels.filter(p => p.id.includes(dnsIdMatcher));
-      if (features.includes('dnsTracking') && !_.isEmpty(dnsPanels)) {
-        //set dns metrics
-        const dnsLatencyMetrics = initFunctionMetricKeys(dnsPanels.map(p => p.id)) as FunctionMetrics;
-        (Object.keys(dnsLatencyMetrics) as (keyof typeof dnsLatencyMetrics)[]).map(fn => {
-          const fq: StructuredFlowQuery = { ...baseQuery, function: fn, type: 'DnsLatencyMs' };
-          promises.push(
-            Result.fromPromise(getMetrics(fq, range)).then(res => {
-              const dnsLatency = res
-                .map(success => {
-                  dnsLatencyMetrics[fn] = success.metrics;
-                  return dnsLatencyMetrics;
-                })
-                .mapError(err => getStructuredHTTPError(err, `DNS Latency`));
-              currentMetrics = { ...currentMetrics, dnsLatency };
-              setMetrics(currentMetrics);
-              return res.map(r => r.stats).or(emptyStats);
-            })
-          );
-        });
+      if (features.includes('dnsTracking')) {
+        const dnsPanels = props.panels.filter(p => p.id.includes(dnsMatcher));
+        if (!_.isEmpty(dnsPanels)) {
+          //set dns metrics
+          const dnsLatencyMetrics = initFunctionMetricKeys(dnsPanels.map(p => p.id)) as FunctionMetrics;
+          (Object.keys(dnsLatencyMetrics) as (keyof typeof dnsLatencyMetrics)[]).map(fn => {
+            const fq: StructuredFlowQuery = { ...baseQuery, function: fn, type: 'DnsLatencyMs' };
+            promises.push(
+              Result.fromPromise(getMetrics(fq, range)).then(res => {
+                const dnsLatency = res
+                  .map(success => {
+                    dnsLatencyMetrics[fn] = success.metrics;
+                    return dnsLatencyMetrics;
+                  })
+                  .mapError(err => getStructuredHTTPError(err, `DNS Latency`));
+                currentMetrics = { ...currentMetrics, dnsLatency };
+                setMetrics(currentMetrics);
+                return res.map(r => r.stats).or(emptyStats);
+              })
+            );
+          });
 
-        const totalDnsLatencyMetric = initFunctionMetricKeys(dnsPanels.map(p => p.id)) as TotalFunctionMetrics;
-        (Object.keys(totalDnsLatencyMetric) as (keyof typeof totalDnsLatencyMetric)[]).map(fn => {
-          const fq: StructuredFlowQuery = { ...baseQuery, function: fn, aggregateBy: 'app', type: 'DnsLatencyMs' };
-          promises.push(
-            Result.fromPromise(getMetrics(fq, range)).then(res => {
-              const totalDnsLatency = res
-                .map(success => {
-                  totalDnsLatencyMetric[fn] = success.metrics[0];
-                  return totalDnsLatencyMetric;
-                })
-                .mapError(err => getStructuredHTTPError(err, `Total DNS Latency`));
-              currentMetrics = { ...currentMetrics, totalDnsLatency };
-              setMetrics(currentMetrics);
-              return res.map(r => r.stats).or(emptyStats);
-            })
-          );
-        });
+          const totalDnsLatencyMetric = initFunctionMetricKeys(dnsPanels.map(p => p.id)) as TotalFunctionMetrics;
+          (Object.keys(totalDnsLatencyMetric) as (keyof typeof totalDnsLatencyMetric)[]).map(fn => {
+            const fq: StructuredFlowQuery = { ...baseQuery, function: fn, aggregateBy: 'app', type: 'DnsLatencyMs' };
+            promises.push(
+              Result.fromPromise(getMetrics(fq, range)).then(res => {
+                const totalDnsLatency = res
+                  .map(success => {
+                    totalDnsLatencyMetric[fn] = success.metrics[0];
+                    return totalDnsLatencyMetric;
+                  })
+                  .mapError(err => getStructuredHTTPError(err, `Total DNS Latency`));
+                currentMetrics = { ...currentMetrics, totalDnsLatency };
+                setMetrics(currentMetrics);
+                return res.map(r => r.stats).or(emptyStats);
+              })
+            );
+          });
+        }
 
-        //set rcode metrics
-        if (dnsPanels.some(p => p.id.includes('rcode_dns_latency_flows'))) {
-          const fqNames: StructuredFlowQuery = {
-            ...baseQuery,
-            aggregateBy: 'DnsName',
-            function: 'count',
-            type: 'DnsFlows'
-          };
-          const fqCodes: StructuredFlowQuery = {
-            ...baseQuery,
-            aggregateBy: 'DnsFlagsResponseCode',
-            function: 'count',
-            type: 'DnsFlows'
-          };
+        // DNS name & rcode
+        const hasRCode = dnsPanels.some(p => p.id === 'dns_rcode_flows');
+        const hasName = dnsPanels.some(p => p.id === 'dns_name_flows');
+        if (hasRCode || hasName) {
+          // Total
           const fqTotal: StructuredFlowQuery = {
             ...baseQuery,
             aggregateBy: 'app',
@@ -313,17 +306,25 @@ export const NetflowOverview = React.forwardRef<NetflowOverviewHandle, NetflowOv
             type: 'DnsFlows'
           };
           promises.push(
-            ...[
-              //get dns names
-              Result.fromPromise(getFlowGenericMetrics(fqNames, range)).then(res => {
-                const dnsName = res
-                  .map(success => success.metrics)
-                  .mapError(err => getStructuredHTTPError(err, `DNS Names`));
-                currentMetrics = { ...currentMetrics, dnsName };
-                setMetrics(currentMetrics);
-                return res.map(r => r.stats).or(emptyStats);
-              }),
-              //get dns response codes
+            Result.fromPromise(getFlowGenericMetrics(fqTotal, range)).then(res => {
+              const totalDnsCount = res
+                .map(success => success.metrics[0])
+                .mapError(err => getStructuredHTTPError(err, `DNS Total`));
+              currentMetrics = { ...currentMetrics, totalDnsCount };
+              setMetrics(currentMetrics);
+              return res.map(r => r.stats).or(emptyStats);
+            })
+          );
+
+          if (hasRCode) {
+            // Get dns response codes
+            const fqCodes: StructuredFlowQuery = {
+              ...baseQuery,
+              aggregateBy: 'DnsFlagsResponseCode',
+              function: 'count',
+              type: 'DnsFlows'
+            };
+            promises.push(
               Result.fromPromise(getFlowGenericMetrics(fqCodes, range)).then(res => {
                 const dnsRCode = res
                   .map(success => success.metrics)
@@ -331,17 +332,28 @@ export const NetflowOverview = React.forwardRef<NetflowOverviewHandle, NetflowOv
                 currentMetrics = { ...currentMetrics, dnsRCode };
                 setMetrics(currentMetrics);
                 return res.map(r => r.stats).or(emptyStats);
-              }),
-              Result.fromPromise(getFlowGenericMetrics(fqTotal, range)).then(res => {
-                const totalDnsCount = res
-                  .map(success => success.metrics[0])
-                  .mapError(err => getStructuredHTTPError(err, `DNS Total`));
-                currentMetrics = { ...currentMetrics, totalDnsCount };
+              })
+            );
+          }
+          if (hasName) {
+            // Get dns names
+            const fqNames: StructuredFlowQuery = {
+              ...baseQuery,
+              aggregateBy: 'DnsName',
+              function: 'count',
+              type: 'DnsFlows'
+            };
+            promises.push(
+              Result.fromPromise(getFlowGenericMetrics(fqNames, range)).then(res => {
+                const dnsName = res
+                  .map(success => success.metrics)
+                  .mapError(err => getStructuredHTTPError(err, `DNS Names`));
+                currentMetrics = { ...currentMetrics, dnsName };
                 setMetrics(currentMetrics);
                 return res.map(r => r.stats).or(emptyStats);
               })
-            ]
-          );
+            );
+          }
         }
       } else {
         setMetrics({
@@ -1076,19 +1088,19 @@ export const NetflowOverview = React.forwardRef<NetflowOverviewHandle, NetflowOv
             doubleWidth: options.graph!.type !== 'donut'
           };
         }
-        case 'name_dns_latency_flows':
-        case 'rcode_dns_latency_flows': {
-          const metricType = id === 'name_dns_latency_flows' ? 'DnsName' : 'DnsFlows'; // TODO: consider adding packets graphs here
+        case 'dns_name_flows':
+        case 'dns_rcode_flows': {
+          const metricType = id === 'dns_name_flows' ? 'DnsName' : 'DnsFlows'; // TODO: consider adding packets graphs here
           const topKMetrics =
-            id === 'name_dns_latency_flows' ? sortMetrics(props.metrics.dnsName) : sortMetrics(props.metrics.dnsRCode);
+            id === 'dns_name_flows' ? sortMetrics(props.metrics.dnsName) : sortMetrics(props.metrics.dnsRCode);
           const namedTotalMetric = props.metrics.totalDnsCount;
           const options = getKebabOptions(id, {
-            showNoError: id === 'rcode_dns_latency_flows' ? true : undefined,
+            showNoError: id === 'dns_rcode_flows' ? true : undefined,
             showTop: true,
             showApp: { text: t('Show total'), value: true },
             graph: { options: ['bar_line', 'donut'], type: 'donut' }
           });
-          const othersName = id === 'rcode_dns_latency_flows' ? 'NoError' : undefined;
+          const othersName = id === 'dns_rcode_flows' ? 'NoError' : undefined;
           const isDonut = options!.graph!.type === 'donut';
           const showTopOnly = isDonut || (options.showTop && !options.showApp!.value);
           const showTotalOnly = !options.showTop && options.showApp!.value;

--- a/web/src/utils/config-validation-hook.ts
+++ b/web/src/utils/config-validation-hook.ts
@@ -10,7 +10,7 @@ import {
   localStorageOverviewIdsKey
 } from './local-storage-hook';
 import { ConfigCapabilities } from './netflow-capabilities-hook';
-import { getDefaultOverviewPanels, OverviewPanel } from './overview-panels';
+import { getAvailablePanels, OverviewPanel } from './overview-panels';
 import { defaultMetricScope, defaultMetricType, setURLFilters } from './router';
 
 type InitState = React.MutableRefObject<string[]>;
@@ -124,11 +124,7 @@ export function useConfigValidation(params: {
         )
       );
       setPanels(
-        getLocalStorage(
-          localStorageOverviewIdsKey,
-          getDefaultOverviewPanels(config.panels),
-          defaultArraySelectionOptions
-        )
+        getLocalStorage(localStorageOverviewIdsKey, getAvailablePanels(config.panels), defaultArraySelectionOptions)
       );
       setFiltersFromURL();
     }

--- a/web/src/utils/netflow-capabilities-hook.ts
+++ b/web/src/utils/netflow-capabilities-hook.ts
@@ -13,7 +13,7 @@ import { Column, ColumnsId } from './columns';
 import { ContextSingleton } from './context';
 import { computeStepInterval, TimeRange } from './datetime';
 import { checkFilterAvailable, getFilterDefinitions } from './filter-definitions';
-import { dnsIdMatcher, droppedIdMatcher, OverviewPanel, rttIdMatcher, tlsIdMatcher } from './overview-panels';
+import { dnsMatcher, droppedIdMatcher, OverviewPanel, rttIdMatcher, tlsIdMatcher } from './overview-panels';
 
 export interface ConfigCapabilities {
   allowLoki: boolean;
@@ -140,7 +140,7 @@ export function useConfigCapabilities(params: {
       panels.filter(
         panel =>
           (isPktDrop || !panel.id.includes(droppedIdMatcher)) &&
-          (isDNSTracking || !panel.id.includes(dnsIdMatcher)) &&
+          (isDNSTracking || !panel.id.includes(dnsMatcher)) &&
           (isFlowRTT || !panel.id.includes(rttIdMatcher)) &&
           (isTLSTracking || !panel.id.includes(tlsIdMatcher))
       ),

--- a/web/src/utils/overview-panels.ts
+++ b/web/src/utils/overview-panels.ts
@@ -2,7 +2,7 @@ import { TFunction } from 'i18next';
 import { AggregateBy, MetricFunction, MetricType, StatFunction } from '../model/flow-query';
 import { Feature, isAllowed } from './features-gate';
 
-export const dnsIdMatcher = 'dns_latency';
+export const dnsMatcher = 'dns_';
 export const rttIdMatcher = 'rtt';
 export const droppedIdMatcher = 'dropped';
 export const tlsIdMatcher = 'tls_';
@@ -24,12 +24,10 @@ export const getFunctionFromId = (id: string) => {
     : 'avg';
 };
 
-export type OverviewPanelRateMetric = 'byte_rates' | 'packet_rates' | 'dropped_byte_rates' | 'dropped_packet_rates';
-export type OverviewPanelLatencyMetric = 'dns_latency' | 'rtt';
-export type OverviewPanelTopLatencyFunction = 'avg' | 'max' | 'p90' | 'p99';
-export type OverviewPanelBottomLatencyFunction = 'min';
-export type OverviewPanelFunction = OverviewPanelTopLatencyFunction | OverviewPanelBottomLatencyFunction;
-export type OverviewPanelMetric = OverviewPanelRateMetric | OverviewPanelLatencyMetric;
+type OverviewPanelRateMetric = 'byte_rates' | 'packet_rates' | 'dropped_byte_rates' | 'dropped_packet_rates';
+type OverviewPanelLatencyMetric = 'dns_latency' | 'rtt';
+type OverviewPanelTopLatencyFunction = 'avg' | 'max' | 'p90' | 'p99';
+type OverviewPanelBottomLatencyFunction = 'min';
 
 export type OverviewPanelId =
   | 'overview'
@@ -41,8 +39,8 @@ export type OverviewPanelId =
   | `${OverviewPanelRateMetric}`
   | `state_dropped_packet_rates`
   | `cause_dropped_packet_rates`
-  | 'name_dns_latency_flows'
-  | 'rcode_dns_latency_flows'
+  | 'dns_name_flows'
+  | 'dns_rcode_flows'
   | 'tls_usage_global'
   | 'tls_per_cipher_suite'
   | 'tls_per_version'
@@ -65,7 +63,7 @@ export type OverviewPanelInfo = {
   tooltip?: string;
 };
 
-export const defaultPanelIds: OverviewPanelId[] = [
+const defaultPanelIds: Set<OverviewPanelId> = new Set([
   'overview',
   'top_sankey',
   'inbound_region',
@@ -77,67 +75,45 @@ export const defaultPanelIds: OverviewPanelId[] = [
   'cause_dropped_packet_rates',
   'top_avg_dns_latency',
   'top_p90_dns_latency',
-  'name_dns_latency_flows',
-  'rcode_dns_latency_flows',
-  'bottom_min_rtt', // should remove from defaults?
+  'dns_name_flows',
+  'dns_rcode_flows',
   'top_avg_rtt',
   'top_p90_rtt',
   'tls_usage_global',
   'tls_per_version'
-];
+]);
 
-export const getDefaultOverviewPanels = (customIds?: string[]): OverviewPanel[] => {
-  let ids: OverviewPanelId[] = ['tls_usage_global', 'tls_per_version', 'tls_per_group', 'tls_per_cipher_suite'];
+// List of available panels with their default selection behavior
+// isSelected can safely be used on feature related panels
+// as these will be filtered on top anyways
+export const getAvailablePanels = (customIds?: string[]): OverviewPanel[] => {
+  const ratesPanels = (m: OverviewPanelRateMetric): OverviewPanelId[] => [`top_avg_${m}`, m];
+  const histogramPanels = (m: OverviewPanelLatencyMetric): OverviewPanelId[] => {
+    return ['avg', 'max', 'p90', 'p99'].map(s => `top_${s}_${m}` as OverviewPanelId).concat([`bottom_min_${m}`]);
+  };
 
-  /* list of panels and default selection behavior
-   *  isSelected can safely be used on feature related panels
-   *  as these will be filtered on top anyways
-   */
-  if (isAllowed(Feature.Overview)) {
-    ids = ids.concat(['overview', 'top_sankey', 'inbound_region']);
-  }
-
-  const metrics: OverviewPanelMetric[] = [
-    'byte_rates',
-    'packet_rates',
-    'dropped_byte_rates',
-    'dropped_packet_rates',
-    'dns_latency',
-    'rtt'
+  // The order here determines the display order
+  const ids: OverviewPanelId[] = [
+    ...(isAllowed(Feature.Overview) ? (['overview', 'top_sankey', 'inbound_region'] as OverviewPanelId[]) : []),
+    ...ratesPanels('byte_rates'),
+    ...ratesPanels('packet_rates'),
+    'tls_usage_global',
+    'tls_per_version',
+    'tls_per_group',
+    'tls_per_cipher_suite',
+    'state_dropped_packet_rates',
+    'cause_dropped_packet_rates',
+    ...ratesPanels('dropped_byte_rates'),
+    ...ratesPanels('dropped_packet_rates'),
+    'dns_name_flows',
+    'dns_rcode_flows',
+    ...histogramPanels('dns_latency'),
+    ...histogramPanels('rtt'),
+    ...(customIds ? customIds.map(id => `${customPanelMatcher}_${id}` as OverviewPanelId) : [])
   ];
-  const functions: OverviewPanelFunction[] = ['avg', 'min', 'max', 'p90', 'p99'];
-  metrics.forEach((m: OverviewPanelMetric) => {
-    // specific graph per feature
-    switch (m) {
-      case 'dropped_byte_rates':
-        ids = ids.concat(['state_dropped_packet_rates', 'cause_dropped_packet_rates']);
-        break;
-      case 'dns_latency':
-        ids = ids.concat(['name_dns_latency_flows', 'rcode_dns_latency_flows']);
-        break;
-    }
-
-    if (['byte_rates', 'packet_rates', 'dropped_byte_rates', 'dropped_packet_rates'].includes(m)) {
-      // rates
-      ids.push(`top_avg_${m as OverviewPanelRateMetric}`);
-      ids.push(m as OverviewPanelRateMetric);
-    } else if (['dns_latency', 'rtt'].includes(m))
-      // latency metrics functions
-      functions.forEach((fn: OverviewPanelFunction) => {
-        if (['avg', 'max', 'p90', 'p99'].includes(fn)) {
-          ids.push(`top_${fn as OverviewPanelTopLatencyFunction}_${m as OverviewPanelLatencyMetric}`);
-        } else {
-          ids.push(`bottom_${fn as OverviewPanelBottomLatencyFunction}_${m as OverviewPanelLatencyMetric}`);
-        }
-      });
-  });
-
-  if (customIds) {
-    ids = ids.concat(customIds.map(id => `${customPanelMatcher}_${id}` as OverviewPanelId));
-  }
 
   return ids.map(id => {
-    return { id, isSelected: defaultPanelIds.includes(id) };
+    return { id, isSelected: defaultPanelIds.has(id) };
   });
 };
 
@@ -313,7 +289,7 @@ export const getOverviewPanelInfo = (
         })
       };
     }
-    case 'name_dns_latency_flows':
+    case 'dns_name_flows':
       return {
         title: t('Top {{limit}} DNS name with total', { limit }),
         topTitle: t('Top {{limit}} DNS name', { limit }),
@@ -322,7 +298,7 @@ export const getOverviewPanelInfo = (
         subtitle: t('Total DNS flow count'),
         tooltip: t('The top DNS name extracted from DNS headers compared to total over the selected interval')
       };
-    case 'rcode_dns_latency_flows':
+    case 'dns_rcode_flows':
       return {
         title: t('Top {{limit}} DNS response code with total', { limit }),
         topTitle: t('Top {{limit}} DNS response code', { limit }),


### PR DESCRIPTION
Backport of https://github.com/netobserv/netobserv-web-console/pull/1673

* [NETOBSERV-2671](https://redhat.atlassian.net/browse/NETOBSERV-2671): support DNS metrics per qname

- DNS qname and rcode are now in their own metric, not mixed up with DNS latency metric. That needs some decoupling between dns_latency and dns_rcode / dns_name models in typescript
- unexport a few types in typescript
- simplify overview-panels => getting ordered list of available panels
- remove rtt min panel from the defaults
- reorder TLS to be below standard rates
- fix: "count" function translates as "increase" in promql
- rework on dns filters to make prom vs loki more comparable
- (unrelated) fix bug in promproxy with nil headers map

* fix review comment

* add a check for dns name panel

---------

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
