### PR TITLE
NETOBSERV-2912: Switch to ubi-minimal-pqc base image for PQC support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -o plugin-backend cmd/plugin-backend.go
 
-FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:1785339196
+FROM --platform=linux/$TARGETARCH registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
 
 COPY --from=web-builder /opt/app-root/web/dist ./web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+# PQC crypto-policies builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8 AS crypto-builder
+RUN microdnf install -y crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    microdnf clean all && rm -rf /var/cache/*
+
 FROM localhost/local-front-build:latest AS web-builder
 
 ARG TARGETARCH
@@ -16,8 +22,9 @@ COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -o plugin-backend cmd/plugin-backend.go
 
-FROM --platform=linux/$TARGETARCH registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
+FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:1785339196
 
+COPY --from=crypto-builder /etc/crypto-policies/ /etc/crypto-policies/
 COPY --from=web-builder /opt/app-root/web/dist ./web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend ./
 USER 65532:65532

--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -34,7 +34,7 @@ COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 go build -ldflags "$LDFLAGS" -mod vendor -o plugin-backend cmd/plugin-backend.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:1785339196
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
 
 COPY --from=web-builder /opt/app-root/web/dist ./web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend ./

--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -1,5 +1,12 @@
 ARG BUILDSCRIPT=
 ARG LDFLAGS=
+
+# PQC crypto-policies builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8 AS crypto-builder
+RUN microdnf install -y crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    microdnf clean all && rm -rf /var/cache/*
+
 FROM docker.io/library/node:24-alpine AS web-builder
 
 USER node
@@ -34,8 +41,9 @@ COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 go build -ldflags "$LDFLAGS" -mod vendor -o plugin-backend cmd/plugin-backend.go
 
-FROM registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
+FROM registry.access.redhat.com/ubi9/ubi-minimal:1785339196
 
+COPY --from=crypto-builder /etc/crypto-policies/ /etc/crypto-policies/
 COPY --from=web-builder /opt/app-root/web/dist ./web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend ./
 


### PR DESCRIPTION
## Summary
- Enable `DEFAULT:PQ` crypto policy for post-quantum cryptography support using a multi-stage build
- A `crypto-builder` stage installs `crypto-policies-scripts`, configures `DEFAULT:PQ`, and the resulting `/etc/crypto-policies/` is copied into the runtime image
- This makes ML-KEM available via OpenSSL without changing the base image
- Based on [openshift/images#230](https://github.com/openshift/images/pull/230)

## Test plan
- [x] Built `Dockerfile.cypress` successfully with crypto-builder approach
- [x] Confirmed `DEFAULT:PQ` crypto policy in built image via `cat /etc/crypto-policies/state/current`
- [x] Verified on FLP repo that e2e tests pass with this approach

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [NETOBSERV-2912](https://redhat.atlassian.net/browse/NETOBSERV-2912)`