### PR TITLE
Fix CopyWebpackPlugin glob errors after v14 upgrade

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -487,8 +487,8 @@ module.exports = {
     }),
     new CopyWebpackPlugin({
       patterns: [
-        { from: path.resolve(__dirname, 'locales'), to: 'locales' },
-        { from: path.resolve(__dirname, 'assets'), to: 'assets' },
+        { from: 'locales', to: 'locales', context: __dirname },
+        { from: 'assets', to: 'assets', context: __dirname },
       ],
     }),
   ],
@@ -607,8 +607,8 @@ if (process.env.FLAVOR === 'static') {
     }),
     new CopyWebpackPlugin({
       patterns: [
-        { from: path.resolve(__dirname, 'locales'), to: 'locales' },
-        { from: path.resolve(__dirname, 'assets'), to: 'assets' },
+        { from: 'locales', to: 'locales', context: __dirname },
+        { from: 'assets', to: 'assets', context: __dirname },
       ],
     }),
   ];

--- a/web/webpack.standalone.js
+++ b/web/webpack.standalone.js
@@ -89,8 +89,8 @@ module.exports = {
     ),
     new CopyWebpackPlugin({
       patterns: [
-        { from: path.resolve(__dirname, 'locales'), to: 'locales' },
-        { from: path.resolve(__dirname, 'assets'), to: 'assets' },
+        { from: 'locales', to: 'locales', context: __dirname },
+        { from: 'assets', to: 'assets', context: __dirname },
       ],
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
## Summary

Fixes webpack build failures introduced by #1313 (copy-webpack-plugin v13 → v14).

The build fails with:

```
ERROR in unable to locate '.../web/locales/**/*' glob
ERROR in unable to locate '.../web/assets/**/*' glob
```

### Root cause

copy-webpack-plugin v14 replaced its internal glob engine (`globby`/`fast-glob`) with `tinyglobby`. Unlike the previous engines, `tinyglobby` does not resolve absolute-path globs when the working directory is not an ancestor of the target path.

Both webpack configs (`webpack.config.ts` and `webpack.standalone.js`) set their context to `web/src/`, while the `locales/` and `assets/` directories live one level up in `web/`. As a result, `tinyglobby` returns empty results and CopyWebpackPlugin reports the glob as not found.

### Fix

Set an explicit `context: __dirname` on each CopyWebpackPlugin pattern so the glob resolves from `web/` instead of `web/src/`.

## Test plan

- [x] `npm run build` succeeds (plugin mode)
- [ ] `npm run build:standalone` succeeds (standalone mode)
- [ ] `npm run build:static` succeeds (static flavor)

Made with [Cursor](https://cursor.com)