### PR TITLE
NETOBSERV-2993: Dashboard test compatibility for tile panels in PF5

### DIFF
--- a/web/cypress/views/dashboards-page.ts
+++ b/web/cypress/views/dashboards-page.ts
@@ -60,11 +60,9 @@ Cypress.Commands.add('checkDashboards', (names) => {
         // Add wait to allow metrics to populate
         cy.wait(2000)
 
-        // Check that graph body doesn't have empty state - use a custom retry mechanism
+        // Verify panel doesn't have empty state - works for both chart panels and tile panels
         cy.byTestID(names[i]).first({ timeout: 120000 }).should($panel => {
-            const $region = $panel.find(graphSelector.graphBody)
-            expect($region.length, `${names[i]} graph region should exist`).to.be.greaterThan(0)
-            expect($region.find('[data-test="empty-state"]').length, `${names[i]} should not be empty`).to.equal(0)
+            expect($panel.find('[data-test="empty-state"]').length, `${names[i]} should not be empty`).to.equal(0)
         })
     }
 })


### PR DESCRIPTION
## Description
Remove requirement for graph body element in checkDashboards test helper. Tile panels (showing summary metrics) don't have PatternFly card body structure in PF5, causing test failures. Simplified logic now only checks for absence of empty-state element, working for both charts and tiles.

Issue seen on 4.16. Tested on 4.18, 4.20 too.

## Dependencies
n/a

## Testing
- 4.16 run: [noo-frontend-tests#156](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/netobserv/job/noo-frontend-tests/156/) Failing tests have 2.0 changes
- 4.18 run: [noo-frontend-tests#157](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/netobserv/job/noo-frontend-tests/157/) Failing tests have 2.0 changes
- 4.20 run: [noo-frontend-tests#159](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/netobserv/job/noo-frontend-tests/159/) Failing tests have 2.0 changes

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
